### PR TITLE
Store Cloudflare token in $HOME/.telepromper/token

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ Here are some example commands:
 
 The CLI supports authentication with Cloudflare Access for secure communication with the Teleprompter service. For local development, it uses a default token.
 
+## Cloudflare Warp Access Control
+
+Teleprompter uses Cloudflare Warp for access control. The authentication token retrieved from Cloudflare is stored in `$HOME/.teleprompter/token`. If the folder does not exist, it will be created. The token file permissions are set to 0600 to ensure it is private to the owner.
+
+## Note on Authentication
+
+Teleprompter has no authentication system of its own.
+
 ## Contributing
 
 Contributions to the Teleprompter CLI are welcome! Please feel free to submit pull requests or create issues for bugs and feature requests.


### PR DESCRIPTION
Add functionality to store Cloudflare authentication token in `$HOME/.teleprompter/token`.

* Import `path`, `os`, and `fs/promises` modules in `src/index.ts`.
* Add `storeToken` function to create the directory and store the token with permissions set to 0600.
* Call `storeToken` function after retrieving the token in `cloudflareAccessLogin`.
* Update `getAccessToken` function to read the token from the file if it exists.
* Add a section to `README.md` explaining that Teleprompter uses CloudFlare Warp for access control and where the token is stored.
* Add a note in `README.md` stating that Teleprompter has no authentication system of its own.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/britt/teleprompter-cli?shareId=b645d74c-f3ec-41d9-9271-e054bd534175).