### PR TITLE
feat: add dotprompt metadata support with model display and validation

### DIFF
--- a/.github/actions/styleguide-action/detect-documentation-root/package.json
+++ b/.github/actions/styleguide-action/detect-documentation-root/package.json
@@ -1,0 +1,1 @@
+{"type": "commonjs"}

--- a/.github/actions/styleguide-action/generate-styleguide/package.json
+++ b/.github/actions/styleguide-action/generate-styleguide/package.json
@@ -1,0 +1,1 @@
+{"type": "commonjs"}

--- a/.github/actions/styleguide-action/identify-publishing-framework/package.json
+++ b/.github/actions/styleguide-action/identify-publishing-framework/package.json
@@ -1,0 +1,1 @@
+{"type": "commonjs"}

--- a/VERIFICATION_PLAN.md
+++ b/VERIFICATION_PLAN.md
@@ -1,0 +1,316 @@
+# Verification Plan
+
+## Prerequisites
+
+- The Teleprompter backend with dotprompt support is deployed and reachable (the `britt/dotprompt-support` branch merged or running via `npx wrangler dev` locally)
+- `TP_URL` environment variable is set to the backend URL (e.g., `http://localhost:8787` for local dev)
+- Cloudflare Access token available (or backend running locally without auth)
+- `bun install` completed in the CLI project
+- `bun run build` succeeds with zero errors
+- `bun test` passes (all unit tests green before verification)
+- `jq` installed for inspecting JSON output
+- At least one LLM provider API key configured (for Scenario 7)
+
+## Scenarios
+
+### Scenario 1: Unit Tests Pass
+
+**Context**: All implementation tasks from the plan are complete. No backend required.
+
+**Steps**:
+1. Run `bun test` from the project root
+2. Run `bunx tsc --noEmit` to verify TypeScript compiles cleanly
+
+**Success Criteria**:
+- [ ] All tests pass (zero failures)
+- [ ] TypeScript compiles with zero errors
+- [ ] No new warnings introduced
+
+**If Blocked**: If tests fail, fix them before proceeding. Do not skip to later scenarios.
+
+---
+
+### Scenario 2: List Prompts Shows Metadata
+
+**Context**: Backend running with at least one dotprompt-formatted prompt and one plain prompt already stored. If none exist, create them in Scenario 3 first, then come back.
+
+**Steps**:
+1. Run: `bun run index.ts list --json -u $TP_URL`
+2. Pipe through jq: `bun run index.ts list --json -u $TP_URL | jq '.[0] | keys'`
+3. Check a dotprompt prompt: `bun run index.ts list --json -u $TP_URL | jq '.[] | select(.metadata.model != null) | {id, model: .metadata.model}'`
+4. Check a plain prompt: `bun run index.ts list --json -u $TP_URL | jq '.[] | select(.metadata == {}) | .id'`
+
+**Success Criteria**:
+- [ ] JSON output includes `metadata` field on every prompt
+- [ ] Dotprompt prompts have populated metadata (e.g., `metadata.model` is a string)
+- [ ] Plain prompts have `metadata: {}`
+- [ ] No crash or error in output
+
+**If Blocked**: If `metadata` is missing from the response, the backend may not have dotprompt support deployed. Verify the backend branch. Ask developer for help.
+
+---
+
+### Scenario 3: Create a Dotprompt Prompt via PUT
+
+**Context**: Backend running.
+
+**Steps**:
+1. Create a dotprompt-formatted prompt via stdin:
+   ```bash
+   echo '---
+   model: anthropic/claude-sonnet-4-20250514
+   config:
+     temperature: 0.3
+   input:
+     schema:
+       name: string
+       topic: string
+   description: A greeting prompt
+   ---
+   Hello {{name}}, let me tell you about {{topic}}.' | bun run index.ts put verify-dotprompt test-ns --json -u $TP_URL
+   ```
+2. Verify the response: check the JSON output for success
+3. Fetch it back:
+   ```bash
+   bun run index.ts get verify-dotprompt --json -u $TP_URL | jq '{id, model: .metadata.model, description: .metadata.description}'
+   ```
+
+**Success Criteria**:
+- [ ] PUT returns success (no error in output)
+- [ ] GET returns the prompt with `metadata.model` = `"anthropic/claude-sonnet-4-20250514"`
+- [ ] GET returns `metadata.description` = `"A greeting prompt"`
+- [ ] GET returns `metadata.config.temperature` = `0.3`
+- [ ] The `prompt` field contains the full dotprompt source (frontmatter + body)
+
+**If Blocked**: If PUT fails with a network error, check `TP_URL` and auth. If it returns 400, the frontmatter YAML may be malformed — check the error detail.
+
+---
+
+### Scenario 4: Create a Plain Prompt (Backward Compatibility)
+
+**Context**: Backend running.
+
+**Steps**:
+1. Create a plain prompt (no frontmatter):
+   ```bash
+   bun run index.ts put verify-plain test-ns "Hello {{name}}, welcome to {{place}}." --json -u $TP_URL
+   ```
+2. Fetch it back:
+   ```bash
+   bun run index.ts get verify-plain --json -u $TP_URL | jq '{id, metadata, prompt}'
+   ```
+
+**Success Criteria**:
+- [ ] PUT returns success
+- [ ] GET returns `metadata: {}` (empty object, not null, not missing)
+- [ ] `prompt` field is exactly `"Hello {{name}}, welcome to {{place}}."`
+- [ ] No frontmatter injected into the prompt text
+
+**If Blocked**: If metadata is null or absent, the backend's `toPrompt` may not be defaulting correctly.
+
+---
+
+### Scenario 5: Validation Error for Malformed Frontmatter
+
+**Context**: Backend running with dotprompt validation enabled.
+
+**Steps**:
+1. Attempt to create a prompt with broken YAML:
+   ```bash
+   echo '---
+   bad: [yaml: unclosed
+     indent: wrong
+   ---
+   Hello {{name}}' | bun run index.ts put verify-bad-yaml test-ns --json -u $TP_URL
+   ```
+2. Inspect the error output
+
+**Success Criteria**:
+- [ ] Command exits with non-zero status or outputs an error JSON
+- [ ] Error message contains the word "validation" or "invalid" or "error" (case-insensitive)
+- [ ] Error message includes detail about the YAML issue (not just "Request failed with status code 400")
+- [ ] The prompt was NOT created — `bun run index.ts get verify-bad-yaml --json -u $TP_URL` returns an error or 404
+
+**If Blocked**: If the CLI shows a generic axios error instead of the validation detail, the error handling from Task 7 is not working. Check the 400 response body parsing.
+
+---
+
+### Scenario 6: Export Preserves Metadata
+
+**Context**: Backend running. `verify-dotprompt` prompt exists from Scenario 3.
+
+**Steps**:
+1. Export the prompt:
+   ```bash
+   bun run index.ts export "verify-dotprompt" --out /tmp/tp-verify --json -u $TP_URL
+   ```
+2. Inspect the exported file:
+   ```bash
+   cat /tmp/tp-verify/verify-dotprompt.json | jq '{id, has_metadata: (.metadata | length > 0), model: .metadata.model}'
+   ```
+3. Verify the full dotprompt source is preserved:
+   ```bash
+   cat /tmp/tp-verify/verify-dotprompt.json | jq '.prompt' | head -3
+   ```
+
+**Success Criteria**:
+- [ ] Exported JSON file exists at the expected path
+- [ ] File contains `metadata` field with `model: "anthropic/claude-sonnet-4-20250514"`
+- [ ] File contains `prompt` field with the full dotprompt source (starts with `---`)
+- [ ] File contains `id` and `namespace` fields
+
+**If Blocked**: If `metadata` is missing from the export, the export data construction was not updated (Task 6).
+
+---
+
+### Scenario 7: Import Round-Trip
+
+**Context**: Backend running. Exported file from Scenario 6 available.
+
+**Steps**:
+1. Modify the exported file to change the ID (so we don't overwrite):
+   ```bash
+   cat /tmp/tp-verify/verify-dotprompt.json | jq '.id = "verify-reimport"' > /tmp/tp-verify/verify-reimport.json
+   ```
+2. Import it:
+   ```bash
+   bun run index.ts import /tmp/tp-verify/verify-reimport.json --json -u $TP_URL
+   ```
+3. Fetch the imported prompt:
+   ```bash
+   bun run index.ts get verify-reimport --json -u $TP_URL | jq '{id, model: .metadata.model, description: .metadata.description}'
+   ```
+
+**Success Criteria**:
+- [ ] Import succeeds (JSON output shows `success: true`)
+- [ ] Fetched prompt has the same metadata as the original (`model`, `description`, `config`)
+- [ ] Prompt text is identical to the original dotprompt source
+
+**If Blocked**: If import fails with a validation error, the prompt text may have been corrupted during export/reimport. Compare the prompt fields byte-for-byte.
+
+---
+
+### Scenario 8: Template Variable Extraction Ignores Frontmatter
+
+**Context**: No backend required. This tests local template processing.
+
+**Steps**:
+1. Create a test file `/tmp/tp-verify/test-extract.ts`:
+   ```typescript
+   import { extractVariables, stripFrontmatter } from "./template-parser"
+
+   const source = `---
+   model: anthropic/claude-sonnet-4-20250514
+   input:
+     schema:
+       name: string
+   ---
+   Hello {{name}}, welcome to {{place}}.
+   {{#if showDetails}}
+   Here are the details: {{details}}
+   {{/if}}`
+
+   const vars = extractVariables(source)
+   console.log("Variables found:", vars.map(v => `${v.name}(${v.type})`).join(", "))
+
+   const stripped = stripFrontmatter(source)
+   console.log("Stripped starts with:", JSON.stringify(stripped.substring(0, 30)))
+   console.log("Contains frontmatter:", stripped.includes("model:"))
+   ```
+2. Run it: `bun /tmp/tp-verify/test-extract.ts`
+
+**Success Criteria**:
+- [ ] Variables found include: `name(string)`, `place(string)`, `showDetails(boolean)`, `details(string)`
+- [ ] Variables do NOT include: `model`, `schema`, `input`, `anthropic`
+- [ ] Stripped text starts with `Hello` (no `---` prefix)
+- [ ] `Contains frontmatter: false`
+
+**If Blocked**: If frontmatter variables leak through, the `stripFrontmatter` function is not being called in `extractVariables`.
+
+---
+
+### Scenario 9: Version History Shows Metadata
+
+**Context**: Backend running. `verify-dotprompt` prompt exists.
+
+**Steps**:
+1. Update the prompt with different metadata:
+   ```bash
+   echo '---
+   model: openai/gpt-4o
+   config:
+     temperature: 0.9
+   description: Updated greeting
+   ---
+   Hey {{name}}, new version about {{topic}}.' | bun run index.ts put verify-dotprompt test-ns --json -u $TP_URL
+   ```
+2. Fetch version history:
+   ```bash
+   bun run index.ts versions verify-dotprompt --json -u $TP_URL | jq '.[] | {version, model: .metadata.model}'
+   ```
+
+**Success Criteria**:
+- [ ] Version history has at least 2 entries
+- [ ] Oldest version shows `metadata.model` = `"anthropic/claude-sonnet-4-20250514"`
+- [ ] Newest version shows `metadata.model` = `"openai/gpt-4o"`
+- [ ] Each version has its own metadata (not shared)
+
+**If Blocked**: If metadata is null on versions, the backend may not be including metadata in the versions endpoint response. Check the backend's `getVersions` SQL query.
+
+---
+
+### Scenario 10: Detail View Shows Metadata (Interactive)
+
+**Context**: Backend running. `verify-dotprompt` prompt exists. Terminal supports interactive mode.
+
+**Steps**:
+1. Run: `bun run index.ts get verify-dotprompt -u $TP_URL` (without `--json`, so it renders the interactive detail view)
+2. Observe the output
+
+**Success Criteria**:
+- [ ] The detail view shows a "Metadata" section
+- [ ] Model is displayed: `anthropic/claude-sonnet-4-20250514` or `openai/gpt-4o` (whichever is current)
+- [ ] Description is displayed
+- [ ] The prompt text panel does NOT show YAML frontmatter (frontmatter is stripped for display)
+- [ ] No crash or rendering glitch
+
+**If Blocked**: If interactive mode crashes, check the Ink component rendering. Run with `--json` to verify data is correct, then debug the component.
+
+---
+
+### Scenario 11: Cleanup
+
+**Context**: All previous scenarios complete.
+
+**Steps**:
+1. Remove test artifacts:
+   ```bash
+   rm -rf /tmp/tp-verify
+   ```
+2. Optionally delete test prompts from backend (if a delete command exists or via curl):
+   ```bash
+   curl -X DELETE $TP_URL/prompts/verify-dotprompt
+   curl -X DELETE $TP_URL/prompts/verify-plain
+   curl -X DELETE $TP_URL/prompts/verify-reimport
+   ```
+
+**Success Criteria**:
+- [ ] Temp files cleaned up
+- [ ] Test prompts removed from backend (optional — they're harmless)
+
+**If Blocked**: Not critical. Skip if delete endpoint requires auth tokens not available in this context.
+
+---
+
+## Verification Rules
+
+- Never use mocks or fakes — all scenarios except 1 and 8 run against the real backend
+- Scenario 8 runs real code (no mocks), just doesn't need the backend
+- Test environments must be fully running copies of real systems
+- If any success criterion fails, verification fails
+- Ask developer for help if blocked, don't guess
+- Scenarios 1 and 8 can run independently (no backend needed)
+- Scenarios 2-7 and 9-10 require the backend with dotprompt support
+- Run Scenario 3 before Scenario 2 if no dotprompt prompts exist yet
+- Scenario 7 depends on Scenario 6's output
+- Scenario 9 depends on Scenario 3's prompt existing

--- a/components/NewPromptForm.tsx
+++ b/components/NewPromptForm.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { Box, Text, useInput, useApp } from 'ink'
 import TextInput from 'ink-text-input'
+import axios from 'axios'
 import httpClient from '../http-client.js'
 
 interface NewPromptFormProps {
@@ -99,11 +100,19 @@ export const NewPromptForm: React.FC<NewPromptFormProps> = ({
       // Success - go back to list
       onSuccess()
     } catch (err) {
-      const errorMsg = err instanceof Error ? err.message : 'Unknown error'
-      setErrorMessage(`Failed to create prompt: ${errorMsg}`)
+      if (axios.isAxiosError(err) && err.response?.status === 400 && err.response?.data?.error) {
+        const msg = err.response.data.detail
+          ? `${err.response.data.error}: ${err.response.data.detail}`
+          : err.response.data.error
+        setErrorMessage(`Validation error: ${msg}`)
+      } else {
+        const errorMsg = err instanceof Error ? err.message : 'Unknown error'
+        setErrorMessage(`Failed to create prompt: ${errorMsg}`)
+      }
       setIsSubmitting(false)
 
       if (verbose) {
+        const errorMsg = err instanceof Error ? err.message : 'Unknown error'
         console.error('Error creating prompt:', errorMsg)
       }
 

--- a/components/PromptDetail.test.tsx
+++ b/components/PromptDetail.test.tsx
@@ -151,4 +151,65 @@ describe("PromptDetail", () => {
     const frame = lastFrame()
     expect(frame).toContain("version")
   })
+
+  test("displays metadata when present", async () => {
+    const mockPrompt = {
+      id: "test-prompt",
+      namespace: "test-namespace",
+      version: 1234567890,
+      prompt: "---\\nmodel: anthropic/claude-sonnet-4-20250514\\n---\\nHello {{name}}",
+      metadata: {
+        model: "anthropic/claude-sonnet-4-20250514",
+        description: "A test prompt",
+        config: { temperature: 0.3 },
+        tools: ["search", "fetch"]
+      }
+    }
+    const mockGet = mock(() => Promise.resolve({ data: mockPrompt }))
+    httpClient.get = mockGet as any
+
+    const { lastFrame } = render(
+      <PromptDetail
+        promptId="test-prompt"
+        url={mockUrl}
+        token={mockToken}
+        onBack={mockOnBack}
+        verbose={false}
+      />
+    )
+
+    await new Promise(resolve => setTimeout(resolve, 100))
+
+    const frame = lastFrame()
+    expect(frame).toContain("Metadata")
+    expect(frame).toContain("anthropic/claude-sonnet-4-20250514")
+    expect(frame).toContain("A test prompt")
+    expect(frame).toContain("search")
+  })
+
+  test("does not show metadata section for plain prompts", async () => {
+    const mockPrompt = {
+      id: "test-prompt",
+      namespace: "test-namespace",
+      version: 1234567890,
+      prompt: "Hello {{name}}",
+      metadata: {}
+    }
+    const mockGet = mock(() => Promise.resolve({ data: mockPrompt }))
+    httpClient.get = mockGet as any
+
+    const { lastFrame } = render(
+      <PromptDetail
+        promptId="test-prompt"
+        url={mockUrl}
+        token={mockToken}
+        onBack={mockOnBack}
+        verbose={false}
+      />
+    )
+
+    await new Promise(resolve => setTimeout(resolve, 100))
+
+    expect(lastFrame()).not.toContain("Metadata")
+  })
 })

--- a/components/PromptDetail.test.tsx
+++ b/components/PromptDetail.test.tsx
@@ -187,6 +187,52 @@ describe("PromptDetail", () => {
     expect(frame).toContain("search")
   })
 
+  test("shows model per version in history", async () => {
+    const mockPrompt = {
+      id: "test-prompt",
+      namespace: "test-namespace",
+      version: 1234567891,
+      prompt: "Hello",
+      metadata: { model: "openai/gpt-4o" }
+    }
+
+    const mockVersions = [
+      { id: "test-prompt", namespace: "test-namespace", version: 1234567891, metadata: { model: "openai/gpt-4o" } },
+      { id: "test-prompt", namespace: "test-namespace", version: 1234567890, metadata: { model: "anthropic/claude-sonnet-4-20250514" } }
+    ]
+
+    const mockGet = mock((url: string) => {
+      if (url.includes('/versions')) {
+        return Promise.resolve({ data: mockVersions })
+      }
+      return Promise.resolve({ data: mockPrompt })
+    })
+    httpClient.get = mockGet as any
+
+    const { lastFrame, stdin } = render(
+      <PromptDetail
+        promptId="test-prompt"
+        url={mockUrl}
+        token={mockToken}
+        onBack={mockOnBack}
+        verbose={false}
+      />
+    )
+
+    // Wait for prompt to load
+    await new Promise(resolve => setTimeout(resolve, 100))
+
+    // Press 'v' to switch to versions view
+    stdin.write("v")
+
+    // Wait for versions to load
+    await new Promise(resolve => setTimeout(resolve, 100))
+
+    const frame = lastFrame()
+    expect(frame).toContain("openai/gpt-4o")
+    expect(frame).toContain("anthropic/claude-sonnet-4-20250514")
+  })
+
   test("does not show metadata section for plain prompts", async () => {
     const mockPrompt = {
       id: "test-prompt",

--- a/components/PromptDetail.tsx
+++ b/components/PromptDetail.tsx
@@ -171,7 +171,8 @@ export const PromptDetail: React.FC<PromptDetailProps> = ({
       const exportData = {
         id: promptToExport.id,
         namespace: promptToExport.namespace,
-        prompt: promptToExport.prompt
+        prompt: promptToExport.prompt,
+        metadata: promptToExport.metadata || {},
       }
 
       await fsPromises.writeFile(
@@ -417,6 +418,9 @@ export const PromptDetail: React.FC<PromptDetailProps> = ({
                 {isCurrent && (
                   <Text bold color="green"> (current)</Text>
                 )}
+                {v.metadata?.model && (
+                  <Text color="green"> [{v.metadata.model}]</Text>
+                )}
               </Box>
             )
           })}
@@ -486,6 +490,9 @@ export const PromptDetail: React.FC<PromptDetailProps> = ({
                 </Text>
                 {isCurrent && (
                   <Text bold color="green"> (current)</Text>
+                )}
+                {v.metadata?.model && (
+                  <Text color="green"> [{v.metadata.model}]</Text>
                 )}
               </Box>
             )

--- a/components/PromptDetail.tsx
+++ b/components/PromptDetail.tsx
@@ -614,6 +614,31 @@ export const PromptDetail: React.FC<PromptDetailProps> = ({
           )}
         </Box>
 
+        {/* Metadata panel */}
+        {prompt.metadata && Object.keys(prompt.metadata).length > 0 && (
+          <Box flexDirection="column" marginTop={1}>
+            <Text bold color="cyan">Metadata</Text>
+            {prompt.metadata.model && (
+              <Text>  Model: <Text color="green">{prompt.metadata.model}</Text></Text>
+            )}
+            {prompt.metadata.description && (
+              <Text>  Description: {prompt.metadata.description}</Text>
+            )}
+            {prompt.metadata.config && (
+              <Text>  Config: {JSON.stringify(prompt.metadata.config)}</Text>
+            )}
+            {prompt.metadata.tools && prompt.metadata.tools.length > 0 && (
+              <Text>  Tools: {prompt.metadata.tools.join(", ")}</Text>
+            )}
+            {prompt.metadata.input?.schema && (
+              <Text>  Input Schema: {JSON.stringify(prompt.metadata.input.schema)}</Text>
+            )}
+            {prompt.metadata.output && (
+              <Text>  Output: {prompt.metadata.output.format || "text"}{prompt.metadata.output.schema ? ` — ${JSON.stringify(prompt.metadata.output.schema)}` : ""}</Text>
+            )}
+          </Box>
+        )}
+
         {/* Separator */}
         <Box>
           <Text color="gray">{'─'.repeat(terminalWidth)}</Text>

--- a/components/PromptDetail.tsx
+++ b/components/PromptDetail.tsx
@@ -3,6 +3,7 @@ import { Box, Text, useInput, useApp, useStdout } from 'ink'
 import TextInput from 'ink-text-input'
 import httpClient from '../http-client.js'
 import { Prompt } from './PromptsList.js'
+import type { PromptMetadata } from '../prompt-types.js'
 import { PromptTestRunner } from './PromptTestRunner.js'
 import * as path from 'path'
 import { promises as fsPromises } from 'fs'
@@ -13,6 +14,7 @@ interface PromptVersion {
   version: number
   created_at?: string
   prompt?: string
+  metadata?: PromptMetadata
 }
 
 interface PromptDetailProps {

--- a/components/PromptTestRunner.test.tsx
+++ b/components/PromptTestRunner.test.tsx
@@ -100,4 +100,27 @@ describe("PromptTestRunner", () => {
     stdin.write("\x1B") // Escape key
     expect(onBack).toHaveBeenCalled()
   })
+
+  test("displays template body without frontmatter", () => {
+    const dotpromptPrompt: Prompt = {
+      id: "test-prompt",
+      namespace: "test-ns",
+      version: 1234567890,
+      prompt: "---\nmodel: anthropic/claude-sonnet-4-20250514\n---\nHello {{name}}"
+    }
+
+    const { lastFrame } = render(
+      <PromptTestRunner
+        prompt={dotpromptPrompt}
+        url="http://localhost"
+        onBack={() => {}}
+      />
+    )
+
+    const frame = lastFrame()
+    // The template body should be visible
+    expect(frame).toContain("Hello")
+    // The frontmatter metadata should NOT appear in the template display
+    expect(frame).not.toContain("model: anthropic")
+  })
 })

--- a/components/PromptTestRunner.tsx
+++ b/components/PromptTestRunner.tsx
@@ -9,7 +9,7 @@ import { ModelSelector } from "./ModelSelector.js"
 import { ResponsePanel } from "./ResponsePanel.js"
 import { ComparisonView } from "./ComparisonView.js"
 import { TestHistory } from "./TestHistory.js"
-import { extractVariables, compileTemplate, VariableInfo } from "../template-parser.js"
+import { extractVariables, compileTemplate, stripFrontmatter, VariableInfo } from "../template-parser.js"
 import {
   createProvider,
   fetchAllModels,
@@ -324,7 +324,7 @@ export const PromptTestRunner: React.FC<PromptTestRunnerProps> = ({
   const contentHeight = Math.max(5, terminalHeight - 8)
 
   // Split template into lines for display (handle escaped characters)
-  const templateText = (prompt.prompt || '')
+  const templateText = stripFrontmatter(prompt.prompt || '')
     .replace(/\\n/g, '\n')
     .replace(/\\t/g, '\t')
     .replace(/\\r/g, '\r')

--- a/components/PromptsList.test.tsx
+++ b/components/PromptsList.test.tsx
@@ -114,6 +114,54 @@ describe("PromptsList", () => {
     expect(mockGet).toHaveBeenCalledWith(`${mockUrl}/prompts`)
   })
 
+  test("displays model name from metadata in list view", async () => {
+    const mockPrompts = [
+      {
+        id: "dotprompt-1",
+        namespace: "dotprompt",
+        version: 1,
+        prompt: "Hello {{name}}",
+        metadata: { model: "claude-3-opus" }
+      },
+      {
+        id: "plain-prompt",
+        namespace: "test",
+        version: 1,
+        prompt: "Just a plain prompt"
+      },
+      {
+        id: "empty-meta",
+        namespace: "test",
+        version: 1,
+        prompt: "Has empty metadata",
+        metadata: {}
+      }
+    ]
+
+    const mockGet = mock(() => Promise.resolve({ data: mockPrompts }))
+    httpClient.get = mockGet as any
+
+    const { lastFrame } = render(
+      <PromptsList
+        url={mockUrl}
+        token={mockToken}
+        verbose={false}
+        onSelectPrompt={mockOnSelectPrompt}
+      />
+    )
+
+    // Wait for data to load
+    await new Promise(resolve => setTimeout(resolve, 100))
+
+    const frame = lastFrame()
+    // Model header should be present
+    expect(frame).toContain("Model")
+    // Prompt with metadata.model should show the model name
+    expect(frame).toContain("claude-3-opus")
+    // Prompts without a model should show em dash
+    expect(frame).toContain("\u2014")
+  })
+
   test("displays instructions for keyboard navigation", async () => {
     const mockGet = mock(() => Promise.resolve({ data: [] }))
     httpClient.get = mockGet as any

--- a/components/PromptsList.tsx
+++ b/components/PromptsList.tsx
@@ -6,7 +6,7 @@ import * as path from 'path'
 import { promises as fsPromises } from 'fs'
 import { NewPromptForm } from './NewPromptForm.js'
 import { PromptTestRunner } from './PromptTestRunner.js'
-import type { Prompt } from '../prompt-types.js'
+import type { Prompt, PromptMetadata } from '../prompt-types.js'
 
 export type { Prompt } from '../prompt-types.js'
 
@@ -16,6 +16,7 @@ interface PromptVersion {
   version: number
   created_at?: string
   prompt?: string
+  metadata?: PromptMetadata
 }
 
 interface PromptsListProps {
@@ -422,7 +423,8 @@ export const PromptsList: React.FC<PromptsListProps> = ({ url, token, verbose = 
           const exportData = {
             id: prompt.id,
             namespace: prompt.namespace,
-            prompt: prompt.prompt
+            prompt: prompt.prompt,
+            metadata: prompt.metadata || {},
           }
 
           await fsPromises.writeFile(
@@ -775,18 +777,20 @@ export const PromptsList: React.FC<PromptsListProps> = ({ url, token, verbose = 
   // Fixed column widths - must be consistent for all rows
   const idWidth = 35
   const namespaceWidth = 25
+  const modelWidth = 30
   const versionWidth = 15
-  const promptWidth = 60
+  const promptWidth = 35
 
   // Helper component for table row
   const TableRow: React.FC<{
     id: string
     namespace: string
+    model: string
     version: string | number
     prompt: string
     isSelected?: boolean
     isHeader?: boolean
-  }> = ({ id, namespace, version, prompt, isSelected = false, isHeader = false }) => (
+  }> = ({ id, namespace, model, version, prompt, isSelected = false, isHeader = false }) => (
     <Box backgroundColor={isSelected && !isHeader ? 'blue' : undefined}>
       <Box width={idWidth}>
         <Text bold={isHeader || isSelected} color={isHeader ? 'cyan' : undefined}>
@@ -799,6 +803,14 @@ export const PromptsList: React.FC<PromptsListProps> = ({ url, token, verbose = 
           color={isHeader ? 'cyan' : (isSelected ? 'white' : 'magenta')}
         >
           {padText(String(namespace), namespaceWidth)}
+        </Text>
+      </Box>
+      <Box width={modelWidth}>
+        <Text
+          bold={isHeader || isSelected}
+          color={isHeader ? 'cyan' : (isSelected ? 'white' : 'gray')}
+        >
+          {padText(String(model), modelWidth)}
         </Text>
       </Box>
       <Box width={versionWidth}>
@@ -863,6 +875,7 @@ export const PromptsList: React.FC<PromptsListProps> = ({ url, token, verbose = 
         <TableRow
           id="ID"
           namespace="Namespace"
+          model="Model"
           version="Version"
           prompt="Prompt"
           isHeader={true}
@@ -870,7 +883,7 @@ export const PromptsList: React.FC<PromptsListProps> = ({ url, token, verbose = 
 
         {/* Separator */}
         <Box>
-          <Text color="gray">{'─'.repeat(idWidth + namespaceWidth + versionWidth + promptWidth)}</Text>
+          <Text color="gray">{'─'.repeat(idWidth + namespaceWidth + modelWidth + versionWidth + promptWidth)}</Text>
         </Box>
       </Box>
 
@@ -885,6 +898,7 @@ export const PromptsList: React.FC<PromptsListProps> = ({ url, token, verbose = 
               key={`${prompt.id}-${actualIndex}`}
               id={prompt.id}
               namespace={prompt.namespace}
+              model={prompt.metadata?.model || '\u2014'}
               version={prompt.version}
               prompt={prompt.prompt || ''}
               isSelected={isSelected}
@@ -896,7 +910,7 @@ export const PromptsList: React.FC<PromptsListProps> = ({ url, token, verbose = 
       {/* Fixed footer - pinned at bottom */}
       <Box flexDirection="column">
         <Box>
-          <Text color="gray">{'─'.repeat(idWidth + namespaceWidth + versionWidth + promptWidth)}</Text>
+          <Text color="gray">{'─'.repeat(idWidth + namespaceWidth + modelWidth + versionWidth + promptWidth)}</Text>
         </Box>
         <Box paddingX={1}>
           <Text color="cyan" dimColor>Press </Text>

--- a/components/PromptsList.tsx
+++ b/components/PromptsList.tsx
@@ -6,14 +6,9 @@ import * as path from 'path'
 import { promises as fsPromises } from 'fs'
 import { NewPromptForm } from './NewPromptForm.js'
 import { PromptTestRunner } from './PromptTestRunner.js'
+import type { Prompt } from '../prompt-types.js'
 
-export interface Prompt {
-  id: string
-  namespace: string
-  version: number
-  prompt?: string
-  created_at?: string
-}
+export type { Prompt } from '../prompt-types.js'
 
 interface PromptVersion {
   id: string

--- a/index.ts
+++ b/index.ts
@@ -209,13 +209,24 @@ program
                 console.log(`Successfully imported prompt: ${prompt.id}`)
               }
             } catch (error) {
-              const errorMsg = error instanceof Error ? error.message : 'Unknown error'
-              if (cmdOptions.json) {
-                results.push({ success: false, file, promptId: prompt.id, error: errorMsg })
+              if (axios.isAxiosError(error) && error.response?.status === 400 && error.response?.data?.error) {
+                const msg = error.response.data.detail
+                  ? `${error.response.data.error}: ${error.response.data.detail}`
+                  : error.response.data.error
+                if (cmdOptions.json) {
+                  results.push({ success: false, file, promptId: prompt.id, error: msg })
+                } else {
+                  console.error(`Validation error for ${prompt.id}: ${msg}`)
+                }
               } else {
-                console.error(`Error importing prompt ${prompt.id}:`, errorMsg)
-                if (verbose && error instanceof Error) {
-                  console.error(`Stack trace: ${error.stack}`)
+                const errorMsg = error instanceof Error ? error.message : 'Unknown error'
+                if (cmdOptions.json) {
+                  results.push({ success: false, file, promptId: prompt.id, error: errorMsg })
+                } else {
+                  console.error(`Error importing prompt ${prompt.id}:`, errorMsg)
+                  if (verbose && error instanceof Error) {
+                    console.error(`Stack trace: ${error.stack}`)
+                  }
                 }
               }
             }
@@ -650,7 +661,8 @@ program
           const exportData = {
             id: prompt.id,
             namespace: prompt.namespace,
-            prompt: prompt.prompt
+            prompt: prompt.prompt,
+            metadata: prompt.metadata || {},
           }
 
           await fsPromises.writeFile(

--- a/index.ts
+++ b/index.ts
@@ -381,24 +381,37 @@ program
         console.log(`Successfully created prompt: ${promptName}`)
       }
     } catch (error) {
-      if (cmdOptions.json) {
-        const errorMsg = error instanceof Error ? error.message : 'Unknown error'
-        console.error(JSON.stringify({ error: errorMsg }))
-      } else {
-        if (axios.isAxiosError(error)) {
-          console.error('Error creating prompt:', error.message)
-          if (error.response) {
-            console.error('Response status:', error.response.status)
-            console.error('Response data:', error.response.data)
-          }
-        } else if (error instanceof Error) {
-          console.error('Error creating prompt:', error.message)
-          if (verbose) {
-            console.error(`Stack trace: ${error.stack}`)
+      if (axios.isAxiosError(error)) {
+        if (error.response?.status === 400 && error.response?.data?.error) {
+          const msg = error.response.data.detail
+            ? `${error.response.data.error}: ${error.response.data.detail}`
+            : error.response.data.error
+          if (cmdOptions.json) {
+            console.error(JSON.stringify({ error: msg }))
+          } else {
+            console.error(`Validation error: ${msg}`)
           }
         } else {
-          console.error('An unknown error occurred while creating the prompt')
+          if (cmdOptions.json) {
+            console.error(JSON.stringify({ error: error.message }))
+          } else {
+            console.error('Error creating prompt:', error.message)
+            if (error.response) {
+              console.error('Response status:', error.response.status)
+              console.error('Response data:', error.response.data)
+            }
+          }
         }
+      } else if (cmdOptions.json) {
+        const errorMsg = error instanceof Error ? error.message : 'Unknown error'
+        console.error(JSON.stringify({ error: errorMsg }))
+      } else if (error instanceof Error) {
+        console.error('Error creating prompt:', error.message)
+        if (verbose) {
+          console.error(`Stack trace: ${error.stack}`)
+        }
+      } else {
+        console.error('An unknown error occurred while creating the prompt')
       }
       process.exit(1)
     }

--- a/prompt-types.test.ts
+++ b/prompt-types.test.ts
@@ -1,0 +1,62 @@
+import { test, expect, describe } from "bun:test"
+import type { PromptMetadata, Prompt } from "./prompt-types"
+
+describe("PromptMetadata", () => {
+  test("accepts a fully-populated object", () => {
+    const meta: PromptMetadata = {
+      model: "anthropic/claude-sonnet-4",
+      config: { temperature: 0.7, maxTokens: 1024 },
+      input: {
+        default: { name: "world" },
+        schema: { type: "object", properties: { name: { type: "string" } } },
+      },
+      output: {
+        format: "json",
+        schema: { type: "object", properties: { result: { type: "string" } } },
+      },
+      tools: ["web_search", "calculator"],
+      description: "A helpful assistant prompt",
+      ext: {
+        custom: { foo: "bar", nested: { deep: true } },
+      },
+    }
+    // If TypeScript compiles this, the type is correct
+    expect(meta.model).toBe("anthropic/claude-sonnet-4")
+    expect(meta.tools).toEqual(["web_search", "calculator"])
+    expect(meta.description).toBe("A helpful assistant prompt")
+    expect(meta.ext?.custom?.foo).toBe("bar")
+  })
+
+  test("accepts an empty object", () => {
+    const meta: PromptMetadata = {}
+    expect(meta).toEqual({})
+  })
+})
+
+describe("Prompt", () => {
+  test("includes metadata field", () => {
+    const prompt: Prompt = {
+      id: "test-prompt",
+      namespace: "default",
+      version: 1,
+      prompt: "Hello {{name}}",
+      created_at: "2024-01-01T00:00:00Z",
+      metadata: {
+        model: "openai/gpt-4o",
+        description: "Test prompt with metadata",
+      },
+    }
+    expect(prompt.metadata?.model).toBe("openai/gpt-4o")
+    expect(prompt.metadata?.description).toBe("Test prompt with metadata")
+  })
+
+  test("metadata is optional for backward compatibility", () => {
+    const prompt: Prompt = {
+      id: "legacy-prompt",
+      namespace: "default",
+      version: 1,
+    }
+    // No metadata field at all - should compile fine
+    expect(prompt.metadata).toBeUndefined()
+  })
+})

--- a/prompt-types.ts
+++ b/prompt-types.ts
@@ -1,0 +1,24 @@
+export interface PromptMetadata {
+  model?: string
+  config?: Record<string, unknown>
+  input?: {
+    default?: Record<string, unknown>
+    schema?: Record<string, unknown>
+  }
+  output?: {
+    format?: string
+    schema?: Record<string, unknown>
+  }
+  tools?: string[]
+  description?: string
+  ext?: Record<string, Record<string, unknown>>
+}
+
+export interface Prompt {
+  id: string
+  namespace: string
+  version: number
+  prompt?: string
+  created_at?: string
+  metadata?: PromptMetadata
+}

--- a/template-parser.test.ts
+++ b/template-parser.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe } from "bun:test"
-import { extractVariables, compileTemplate, VariableInfo } from "./template-parser"
+import { extractVariables, compileTemplate, stripFrontmatter, VariableInfo } from "./template-parser"
 
 describe("template-parser", () => {
   describe("extractVariables", () => {
@@ -100,5 +100,51 @@ describe("template-parser", () => {
       const result = compileTemplate("{{#unless disabled}}Active{{/unless}}", { disabled: false })
       expect(result).toBe("Active")
     })
+  })
+})
+
+describe("stripFrontmatter", () => {
+  test("strips YAML frontmatter from dotprompt source", () => {
+    const source = "---\nmodel: test\nconfig:\n  temperature: 0.5\n---\nHello {{name}}"
+    expect(stripFrontmatter(source)).toBe("Hello {{name}}")
+  })
+
+  test("returns plain template unchanged", () => {
+    expect(stripFrontmatter("Hello {{name}}")).toBe("Hello {{name}}")
+  })
+
+  test("handles empty frontmatter", () => {
+    expect(stripFrontmatter("---\n---\nHello {{name}}")).toBe("Hello {{name}}")
+  })
+
+  test("handles CRLF line endings", () => {
+    expect(stripFrontmatter("---\r\nmodel: test\r\n---\r\nHello {{name}}")).toBe("Hello {{name}}")
+  })
+
+  test("does not strip --- that appears mid-template", () => {
+    expect(stripFrontmatter("Draw a line:\n---\nEnd")).toBe("Draw a line:\n---\nEnd")
+  })
+
+  test("handles frontmatter-only source (no body)", () => {
+    expect(stripFrontmatter("---\nmodel: test\n---\n")).toBe("")
+  })
+})
+
+describe("extractVariables with dotprompt", () => {
+  test("extracts variables from template body, ignoring frontmatter", () => {
+    const source = "---\nmodel: test\ninput:\n  schema:\n    name: string\n---\nHello {{name}}, welcome to {{place}}"
+    const vars = extractVariables(source)
+    expect(vars.map(v => v.name)).toContain("name")
+    expect(vars.map(v => v.name)).toContain("place")
+    expect(vars.map(v => v.name)).not.toContain("model")
+  })
+})
+
+describe("compileTemplate with dotprompt", () => {
+  test("compiles template body, ignoring frontmatter", () => {
+    const source = "---\nmodel: test\n---\nHello {{name}}"
+    const result = compileTemplate(source, { name: "World" })
+    expect(result).toBe("Hello World")
+    expect(result).not.toContain("---")
   })
 })

--- a/template-parser.ts
+++ b/template-parser.ts
@@ -5,27 +5,35 @@ export interface VariableInfo {
   type: "string" | "boolean" | "array"
 }
 
+const frontmatterRegex = /^---[ \t]*(?:\r\n|\r|\n)(?:[\s\S]*?(?:\r\n|\r|\n))?---[ \t]*(?:\r\n|\r|\n|$)/
+
+export function stripFrontmatter(source: string): string {
+  if (!source.startsWith("---")) return source
+  return source.replace(frontmatterRegex, "")
+}
+
 export function extractVariables(template: string): VariableInfo[] {
+  const body = stripFrontmatter(template)
   const variables = new Map<string, VariableInfo>()
 
   // Match #if blocks: {{#if varname}}
   const ifRegex = /\{\{#if\s+([a-zA-Z_][a-zA-Z0-9_.]*)\}\}/g
   let match
-  while ((match = ifRegex.exec(template)) !== null) {
+  while ((match = ifRegex.exec(body)) !== null) {
     const name = match[1]
     variables.set(name, { name, type: "boolean" })
   }
 
   // Match #unless blocks: {{#unless varname}}
   const unlessRegex = /\{\{#unless\s+([a-zA-Z_][a-zA-Z0-9_.]*)\}\}/g
-  while ((match = unlessRegex.exec(template)) !== null) {
+  while ((match = unlessRegex.exec(body)) !== null) {
     const name = match[1]
     variables.set(name, { name, type: "boolean" })
   }
 
   // Match #each blocks: {{#each varname}}
   const eachRegex = /\{\{#each\s+([a-zA-Z_][a-zA-Z0-9_.]*)\}\}/g
-  while ((match = eachRegex.exec(template)) !== null) {
+  while ((match = eachRegex.exec(body)) !== null) {
     const name = match[1]
     variables.set(name, { name, type: "array" })
   }
@@ -33,7 +41,7 @@ export function extractVariables(template: string): VariableInfo[] {
   // Match simple variables: {{name}} or {{user.email}}
   // This regex avoids matching helpers like {{#if}}, {{/if}}, {{else}}
   const simpleVarRegex = /\{\{([a-zA-Z_][a-zA-Z0-9_.]*)\}\}/g
-  while ((match = simpleVarRegex.exec(template)) !== null) {
+  while ((match = simpleVarRegex.exec(body)) !== null) {
     const name = match[1]
     // Skip built-ins and already-typed variables
     if (!["this", "else"].includes(name) && !variables.has(name)) {
@@ -48,6 +56,7 @@ export function compileTemplate(
   template: string,
   variables: Record<string, unknown>
 ): string {
-  const compiled = Handlebars.compile(template)
+  const body = stripFrontmatter(template)
+  const compiled = Handlebars.compile(body)
   return compiled(variables)
 }


### PR DESCRIPTION
## Summary

- Added shared `PromptMetadata` type with model, config, tools, description, and input/output schema fields
- Strip YAML frontmatter from templates so metadata fields aren't extracted as template variables
- Display model metadata in prompts list view (new Model column) and detail view with per-version model tracking
- Implement structured validation error handling for 400 responses across import, create, and put commands
- Preserve metadata through export/import cycle for round-trip integrity
- Added comprehensive test coverage for all new functionality using `bun:test`

## Test Plan

- [x] List view displays Model column with metadata.model or em dash for missing model
- [x] Detail view shows Metadata panel when present, with per-version model in history
- [x] Frontmatter stripped from template display in test runner
- [x] Validation errors from 400 responses show structured error details
- [x] Metadata preserved when exporting and importing prompts
- [x] All test files use bun:test per CLAUDE.md